### PR TITLE
Add transaction mode for update queries

### DIFF
--- a/db/src/sql.rs
+++ b/db/src/sql.rs
@@ -19,8 +19,12 @@ pub enum Parameter {
 #[derive(Debug, Deserialize, Serialize)]
 // Response represents the outcome of an operation that changes rows.
 pub struct Response {
+    #[serde(skip_serializing_if = "is_zero")]
     pub last_insert_id: i64,
+    #[serde(skip_serializing_if = "is_zero")]
     pub rows_affected: i64,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub error: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -55,4 +59,8 @@ pub enum DataType {
     Real,
     Text,
     Blob,
+}
+
+fn is_zero(num: &i64) -> bool {
+    *num == 0
 }


### PR DESCRIPTION
### Context
Adding transaction mode for update query.

### Approach
This work is a bit tricky. `Rustqlite::Transaction` implements the trait `Deref<type=Connection>`. As the result, we want to use a same object (a.k.a: polymorphism) on the Transaction and Connection object. There is other tricky problem is Transaction's lifetime is tied to the Connection, so any moving of the Transaction will require us to move the Connection as well.

The approach is implementing enum `WrappedConnection` that can be either a naked connection or a transaction. This enum also implement the trait `Deref<type=Connection>` to allow WrappedConnection acted as a connection either in Connection or Transaction mode.

- [x] Write tests
- [x] +1 from @hqt


### Dependencies and References

### Risks