### PR TITLE
Add HTTP service to handle API requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "db",
     "raftstore",
     "grpc",
+    "http",
     "dust_util"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,10 @@
 
 members = [
     "db",
-    "raftstore",
+    "command",
+    "dust_util",
     "grpc",
     "http",
-    "dust_util"
+    "raftstore",
+    "store"
 ]

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "db"
+name = "command"
 version = "0.1.0"
 authors = ["Huynh Quang Thao <huynhquangthao@gmail.com>"]
 edition = "2018"
@@ -7,8 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rusqlite = { version = "0.25.3", features = ["serde_json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-dust_util = { path = "../dust_util" }
-command = { path = "../command" }

--- a/command/src/lib.rs
+++ b/command/src/lib.rs
@@ -1,15 +1,28 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ExecuteRequest {
+    pub request: Request,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct QueryRequest {
+    pub request: Request,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Request {
     pub transaction: bool,
     pub statements: Box<[Statement]>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Statement {
     pub sql: String,
     pub parameters: Box<[Parameter]>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
 pub enum Parameter {
     Integer(i64),
     Real(f64),

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1,8 +1,8 @@
 use rusqlite::{Connection, ToSql, Transaction};
-use crate::sql::{Request, Response, Statement, Rows, Value, DataType, Parameter};
 use std::ops::{Deref};
 use rusqlite::types::ValueRef;
 use std::str;
+use command::{Value, Rows, Request, Response, DataType, Parameter, Statement};
 
 const FK_CHECKS: &str = "PRAGMA foreign_keys";
 const FK_CHECKS_ENABLED: &str = "PRAGMA foreign_keys=ON";

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,3 +1,2 @@
 mod db;
-mod sql;
 

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "http"
+version = "0.1.0"
+authors = ["Huynh Quang Thao <huynhquangthao@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+hyper = { version = "0.14.6", features = ["full"] }
+tokio = { version = "1.5.0", features = ["full", "test-util"] }
+tokio-test = "0.4.1"
+futures = "0.3.15"
+futures-util = { version = "0.3", default-features = false }
+rand = "0.8"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -8,8 +8,12 @@ edition = "2018"
 
 [dependencies]
 hyper = { version = "0.14.6", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tokio = { version = "1.5.0", features = ["full", "test-util"] }
 tokio-test = "0.4.1"
 futures = "0.3.15"
 futures-util = { version = "0.3", default-features = false }
 rand = "0.8"
+command = { path = "../command" }
+store = { path = "../store" }

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,0 +1,1 @@
+mod service;

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -1,0 +1,145 @@
+use hyper::{Server, Request, Body, Response, Method, StatusCode};
+use std::net::SocketAddr;
+use hyper::service::{make_service_fn, service_fn};
+use std::sync::Arc;
+use hyper::server::conn::AddrStream;
+use hyper::Client;
+use futures::{TryFutureExt};
+use tokio::runtime::{Builder, Runtime};
+use tokio::sync::oneshot::{Sender, Receiver};
+use std::time::Duration;
+
+// Service provides a HTTP service
+pub struct Service {
+    addr: String,
+    socket_addr: Option<SocketAddr>,
+    thread_pool: Runtime,
+    tx: Sender<()>,
+    rx: Option<Receiver<()>>,
+    core: Arc<ServiceCore>,
+}
+
+// ServiceCore stores all data that need to access across requests
+struct ServiceCore {}
+
+impl Service {
+    pub fn new(thread_size: usize, addr: String) -> Service {
+        // manually setup runtime environment instead of using the conventional macro #[tokio::main]
+        let thread_pool = Builder::new_multi_thread()
+            .enable_all()
+            .max_blocking_threads(thread_size)
+            .worker_threads(thread_size)
+            .thread_name("http-server")
+            .on_thread_start(|| {
+                println!("http server started");
+            })
+            .on_thread_stop(|| {
+                println!("stopping http server");
+            })
+            .build().unwrap();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let core = Arc::new(ServiceCore {});
+
+        Service {
+            addr,
+            socket_addr: None,
+            thread_pool,
+            tx,
+            rx: Some(rx),
+            core,
+        }
+    }
+
+    pub fn start(&mut self) {
+        let addr: SocketAddr = self.addr.parse().expect("Unable to parse socket address");
+
+        // https://www.fpcomplete.com/blog/captures-closures-async/
+        // inside the closure, value is captured with the static lifetime.
+        // We need to clone everytime coming to the closure.
+        // Otherwise, Rust will move the object to avoid outlive the original one, which possibly result in compile error
+        let core = self.core.clone();
+        // closure for every connection from client
+        let service = make_service_fn(move |_conn: &AddrStream| {
+            let core = core.clone();
+            async move {
+                // Create a status service.
+                Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| { // closure for every request
+                    let core = core.clone();
+                    router(core, req)
+                }))
+            }
+        });
+
+        // enter the reactor
+        let _incoming = self.thread_pool.enter();
+
+        let server = Server::bind(&addr).serve(service);
+        self.socket_addr = Some(server.local_addr());
+        let rx = self.rx.take().unwrap();
+        let graceful = server
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .map_err(|e| eprintln!("status server error {:?}", e));
+        self.thread_pool.spawn(graceful);
+        eprintln!("started service ...");
+    }
+
+    pub fn stop(self) {
+        let _ = self.tx.send(());
+        self.thread_pool.shutdown_timeout(Duration::from_secs(10));
+    }
+
+    // Return listening address, this may only be used for outer test to get the real address
+    // because we may use "127.0.0.1:0" in test to avoid port conflict.
+    pub fn listening_addr(&self) -> SocketAddr {
+        self.socket_addr.unwrap()
+    }
+}
+
+async fn router(_srv: Arc<ServiceCore>, req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/ping") => Ok(Response::new(Body::from("pong"))),
+
+        // Return the 404 Not Found for other routes.
+        _ => {
+            let mut not_found = Response::default();
+            *not_found.status_mut() = StatusCode::NOT_FOUND;
+            Ok(not_found)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper::Uri;
+    use tokio_test::block_on;
+
+    #[test]
+    fn test_ping() {
+        let mut service = Service::new(1, "127.0.0.1:0".to_string());
+        service.start();
+
+        let endpoint = Uri::builder()
+            .scheme("http")
+            .authority(service.listening_addr().to_string().as_str())
+            .path_and_query("/ping")
+            .build()
+            .unwrap();
+
+        let client = Client::new();
+        let handle = service.thread_pool.spawn(async move {
+            let resp = client.get(endpoint).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+
+            let bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+            let text = String::from_utf8(bytes.into_iter().collect()).unwrap();
+            assert_eq!(text, "pong");
+        });
+
+        block_on(handle).unwrap();
+        service.stop();
+    }
+}

--- a/http/src/service.rs
+++ b/http/src/service.rs
@@ -1,29 +1,39 @@
 use hyper::{Server, Request, Body, Response, Method, StatusCode};
 use std::net::SocketAddr;
 use hyper::service::{make_service_fn, service_fn};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use hyper::server::conn::AddrStream;
 use hyper::Client;
-use futures::{TryFutureExt};
+use futures::{TryFutureExt, TryStreamExt};
 use tokio::runtime::{Builder, Runtime};
 use tokio::sync::oneshot::{Sender, Receiver};
 use std::time::Duration;
+use store::{Database, RaftControl};
+use serde::Serialize;
+use futures::future::ok;
+use command::ExecuteRequest;
+
+pub trait DbStore: Database + RaftControl + Clone + Send + 'static {}
 
 // Service provides a HTTP service
-pub struct Service {
+pub struct Service<T> where T: DbStore {
     addr: String,
     socket_addr: Option<SocketAddr>,
     thread_pool: Runtime,
     tx: Sender<()>,
     rx: Option<Receiver<()>>,
-    core: Arc<ServiceCore>,
+    core: ServiceCore<T>,
 }
 
 // ServiceCore stores all data that need to access across requests
-struct ServiceCore {}
+#[derive(Default, Clone)]
+struct ServiceCore<T> where T: DbStore {
+    store: Arc<Mutex<T>>,
+}
 
-impl Service {
-    pub fn new(thread_size: usize, addr: String) -> Service {
+impl<T> Service<T> where T: DbStore {
+    pub fn new(thread_size: usize, addr: String, store: T) -> Service<T>
+    {
         // manually setup runtime environment instead of using the conventional macro #[tokio::main]
         let thread_pool = Builder::new_multi_thread()
             .enable_all()
@@ -39,7 +49,7 @@ impl Service {
             .build().unwrap();
 
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let core = Arc::new(ServiceCore {});
+        let core = ServiceCore { store: Arc::new(Mutex::new(store)) };
 
         Service {
             addr,
@@ -63,7 +73,6 @@ impl Service {
         let service = make_service_fn(move |_conn: &AddrStream| {
             let core = core.clone();
             async move {
-                // Create a status service.
                 Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| { // closure for every request
                     let core = core.clone();
                     router(core, req)
@@ -76,6 +85,7 @@ impl Service {
 
         let server = Server::bind(&addr).serve(service);
         self.socket_addr = Some(server.local_addr());
+
         let rx = self.rx.take().unwrap();
         let graceful = server
             .with_graceful_shutdown(async move {
@@ -98,17 +108,67 @@ impl Service {
     }
 }
 
-async fn router(_srv: Arc<ServiceCore>, req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+async fn router<T>(srv: ServiceCore<T>, req: Request<Body>) -> Result<Response<Body>, hyper::Error> where T: DbStore {
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/ping") => Ok(Response::new(Body::from("pong"))),
+        (&Method::POST, "/db/execute") => { execute_query(srv.clone(), req).await }
 
         // Return the 404 Not Found for other routes.
-        _ => {
-            let mut not_found = Response::default();
-            *not_found.status_mut() = StatusCode::NOT_FOUND;
-            Ok(not_found)
-        }
+        _ => err_response(StatusCode::NOT_FOUND, "")
     }
+}
+
+async fn execute_query<T>(core: ServiceCore<T>, req: Request<Body>) -> hyper::Result<Response<Body>> where T: DbStore {
+    let mut body = Vec::new();
+    req.into_body()
+        .try_for_each(|bytes| {
+            body.extend(bytes);
+            ok(())
+        })
+        .await?;
+
+    let r: ExecuteRequest = match serde_json::from_slice(&body) {
+        Ok(er) => er,
+        Err(err) => {
+            return err_response(
+                StatusCode::BAD_REQUEST,
+                err.to_string(),
+            );
+        }
+    };
+
+    let store = &mut core.store.lock().unwrap();
+    return match store.execute(r) {
+        Ok(result) => success_response(result),
+        Err(err) => err_response(
+            StatusCode::BAD_REQUEST,
+            err.to_string(),
+        )
+    };
+}
+
+// err_response serialize error request with message and error code
+fn err_response<M>(status_code: StatusCode, message: M) -> hyper::Result<Response<Body>>
+    where M: Into<Body>
+{
+    Ok(Response::builder()
+        .status(status_code)
+        .body(message.into())
+        .unwrap()
+    )
+}
+
+// success_response serializes message to json string
+fn success_response<M>(message: M) -> hyper::Result<Response<Body>>
+    where M: Serialize
+{
+    return match serde_json::to_string(&message) {
+        Ok(str) => Ok(Response::new(Body::from(str))),
+        Err(err) => err_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            err.to_string(),
+        )
+    };
 }
 
 #[cfg(test)]
@@ -116,10 +176,52 @@ mod tests {
     use super::*;
     use hyper::Uri;
     use tokio_test::block_on;
+    use command::{ExecuteRequest, QueryRequest, Rows, Statement};
+    use store::Error;
+
+    #[derive(Default, Clone)]
+    struct MockStore {}
+
+    impl RaftControl for MockStore {
+        fn join(&mut self, _id: String, _addr: String) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn remove(&mut self, _id: String) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn leader_id(&self) -> Result<String, Error> {
+            Ok("1".to_string())
+        }
+    }
+
+    impl Database for MockStore {
+        fn execute(&mut self, _req: ExecuteRequest) -> Result<Vec<command::Response>, Error> {
+            let mut results = Vec::new();
+            results.push(command::Response {
+                last_insert_id: 1,
+                rows_affected: 1,
+                error: "".to_string(),
+            });
+            results.push(command::Response {
+                last_insert_id: 2,
+                rows_affected: 1,
+                error: "".to_string(),
+            });
+            Ok(results)
+        }
+
+        fn query(&self, _req: QueryRequest) -> Result<Rows<'static>, Error> {
+            todo!()
+        }
+    }
+
+    impl DbStore for MockStore {}
 
     #[test]
     fn test_ping() {
-        let mut service = Service::new(1, "127.0.0.1:0".to_string());
+        let mut service = Service::new(1, "127.0.0.1:0".to_string(), MockStore {});
         service.start();
 
         let endpoint = Uri::builder()
@@ -137,6 +239,76 @@ mod tests {
             let bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
             let text = String::from_utf8(bytes.into_iter().collect()).unwrap();
             assert_eq!(text, "pong");
+        });
+
+        block_on(handle).unwrap();
+        service.stop();
+    }
+
+    #[test]
+    fn test_not_found() {
+        let mut service = Service::new(1, "127.0.0.1:0".to_string(), MockStore {});
+        service.start();
+
+        let endpoint = Uri::builder()
+            .scheme("http")
+            .authority(service.listening_addr().to_string().as_str())
+            .path_and_query("/random_path")
+            .build()
+            .unwrap();
+
+        let client = Client::new();
+        let handle = service.thread_pool.spawn(async move {
+            let resp = client.get(endpoint).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        });
+
+        block_on(handle).unwrap();
+        service.stop();
+    }
+
+    #[test]
+    fn test_execute_query() {
+        let mut service = Service::new(1, "127.0.0.1:0".to_string(), MockStore {});
+        service.start();
+
+        let endpoint = Uri::builder()
+            .scheme("http")
+            .authority(service.listening_addr().to_string().as_str())
+            .path_and_query("/db/execute")
+            .build()
+            .unwrap();
+
+        let mut req = Request::new(Body::from(
+            serde_json::to_string(&command::ExecuteRequest {
+                request: command::Request {
+                    transaction: false,
+                    statements: Box::new([
+                        Statement {
+                            sql: r#"INSERT INTO foo(id, name) VALUES(1, "fiona")"#.to_string(),
+                            parameters: Box::new([]),
+                        },
+                    ]),
+                }
+            }).unwrap(),
+        ));
+        *req.method_mut() = Method::POST;
+        *req.uri_mut() = endpoint;
+        req.headers_mut().insert(
+            hyper::header::CONTENT_TYPE,
+            hyper::header::HeaderValue::from_static("application/json"),
+        );
+
+        let handle = service.thread_pool.spawn(async move {
+            let resp = Client::new().request(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+
+            let bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+            let text = String::from_utf8(bytes.into_iter().collect()).unwrap();
+            assert_eq!(
+                r#"[{"last_insert_id":1,"rows_affected":1},{"last_insert_id":2,"rows_affected":1}]"#,
+                text
+            );
         });
 
         block_on(handle).unwrap();

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "db"
+name = "store"
 version = "0.1.0"
 authors = ["Huynh Quang Thao <huynhquangthao@gmail.com>"]
 edition = "2018"
@@ -7,8 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rusqlite = { version = "0.25.3", features = ["serde_json"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-dust_util = { path = "../dust_util" }
+thiserror = "1.0"
 command = { path = "../command" }

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -1,0 +1,28 @@
+use command::{Response, QueryRequest, Rows, ExecuteRequest};
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {}
+
+// Database is the interface any queryable system must implement
+pub trait Database {
+    // Execute executes a slice of queries, each of which is not expected
+    // to return rows. If tx is true, then either all queries will be executed
+    // successfully or it will as though none executed.
+    fn execute(&mut self, req: ExecuteRequest) -> Result<Vec<Response>, Error>;
+
+    // Query executes a slice of queries, each of which returns rows.
+    fn query(&self, req: QueryRequest) -> Result<Rows<'static>, Error>;
+}
+
+// RaftControl is the interface the Raft-based database must implement.
+pub trait RaftControl {
+    // join joins the node with the given ID, reachable at addr, to this node.
+    fn join(&mut self, id: String, addr: String) -> Result<(), Error>;
+
+
+    // remove removes the node, specified by id, from the cluster.
+    fn remove(&mut self, id: String) -> Result<(), Error>;
+
+    // leader returns the Raft address of the leader of the cluster.
+    fn leader_id(&self) -> Result<String, Error>;
+}


### PR DESCRIPTION
### Context
Adding HTTP service to handle API requests

### Approach
This is the first PR to implement a HTTP service. Some technical information:
- Using hyper (a very basic implementation of HTTP spec) for HTTP service
- Using tonic for the asynchronous runtime environment

This PR aims to structure the code good enough to be able to run in the long run.

- [x] Write tests
- [x] +1 from @hqt


### Dependencies and References

### Risks
